### PR TITLE
critical update readSaveOutput.R

### DIFF
--- a/R/readSaveOutput.R
+++ b/R/readSaveOutput.R
@@ -82,7 +82,7 @@ readWatoutFile <- function(workingDirectory,
                     coreNumber, "/", fileName, sep = "")
   
   getWatoutData <- read.table(fileName, header = FALSE, sep = "", skip = 6)
-  timeSeries <- seq(fileCioInfo$startSim, fileCioInfo$endSim, by="days")
+  timeSeries <- seq(fileCioInfo$startEval, fileCioInfo$endSim, by="days")
   
   counter <- length(output)
   trim <- c(which(timeSeries ==  fromToDate[1]), 


### PR DESCRIPTION
CRICITICAL: all simulation that use extraction from "watout.dat" must be rerun because of error in the extraction function with this option