### PR TITLE
fix: add yearlyOutputLoc function to runSWATpar - NOTE: this does not…

### DIFF
--- a/R/executeSWAT.R
+++ b/R/executeSWAT.R
@@ -141,6 +141,7 @@
                                                       "updateCalibrationFile",
                                                       "readChannelFile",
                                                       "readOutputRchFile",
+                                                      "yearlyOutputLoc",
                                                       "getRchNumber")) %dopar% {
                                                         
                                                         runSWATSequential(i, 


### PR DESCRIPTION
This fix does not affect simulation result